### PR TITLE
Fix | Endpoint Pagination Issue

### DIFF
--- a/src/Fca.php
+++ b/src/Fca.php
@@ -114,6 +114,7 @@ class Fca extends Connector implements HasPagination
             protected function getPageItems(Response $response, Request $request): array
             {
                 $items = $request->createDtoFromResponse($response);
+
                 return $items ?? $response->json('Data', []);
             }
 

--- a/src/Fca.php
+++ b/src/Fca.php
@@ -113,7 +113,8 @@ class Fca extends Connector implements HasPagination
              */
             protected function getPageItems(Response $response, Request $request): array
             {
-                return $request->createDtoFromResponse($response);
+                $items = $request->createDtoFromResponse($response);
+                return $items ?? $response->json('Data', []);
             }
 
             /**

--- a/src/Requests/GetEndpoint.php
+++ b/src/Requests/GetEndpoint.php
@@ -6,8 +6,9 @@ namespace CraigPotter\Fca\Requests;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\PaginationPlugin\Contracts\Paginatable;
 
-class GetEndpoint extends Request
+class GetEndpoint extends Request implements Paginatable
 {
     /**
      * The HTTP method of the request.


### PR DESCRIPTION
The recent v1 release implemented Saloon Pagination v2 and set the getPageItems method to get the items from the request createDtoFromResponse method however the endpoint request does not have a DTO however does implement pagination. 

This PR fixes it to either return the DTOs, the items from the data property on the request or an empty array. 